### PR TITLE
Folder or file could start with dot

### DIFF
--- a/libraries/vendor/joomla/filter/src/InputFilter.php
+++ b/libraries/vendor/joomla/filter/src/InputFilter.php
@@ -1016,14 +1016,14 @@ class InputFilter
 	 */
 	private function cleanPath($source)
 	{
-		$linuxPattern = '/^[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*([\\\\\/]+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
+		$linuxPattern = '/^[A-Za-z0-9_\/-]+[A-Za-z0-9_\.-]*([\\\\\/]+[A-Za-z0-9_\.-]+)*$/';
 
 		if (preg_match($linuxPattern, $source))
 		{
 			return preg_replace('~/+~', '/', $source);
 		}
 
-		$windowsPattern = '/^([A-Za-z]:(\\\\|\/))?[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*((\\\\|\/)+[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*)*$/';
+		$windowsPattern = '/^([A-Za-z]:(\\\\|\/))?[A-Za-z0-9_-]+[A-Za-z0-9_\.-]*((\\\\|\/)+[A-Za-z0-9_\.-]+)*$/';
 
 		if (preg_match($windowsPattern, $source))
 		{


### PR DESCRIPTION
Files and folders starting with dot didn't pass the regexpr test. So for example \var\www\.tmp path didn't pass the test, which causes error during Joomla update.

### Summary of Changes
Modified Reg Expressions to include files and / or folders starting with dot. The check was brought by this PR https://github.com/joomla/joomla-cms/pull/32076 which adds InputFilter to temp path settings, however ignoring folders with dot at the beginning.

### Testing Instructions
Go to Joomla settings and change your Temp path to some folder with dot at the beginning, for example \path_to_joomla\.tmp (and create that folder of course). Go to Joomla update, and try to install the update.


### Actual result BEFORE applying this Pull Request
Error is displayed, update is not installed.


### Expected result AFTER applying this Pull Request
No errror, update is installed.


### Documentation Changes Required
None
