### PR TITLE
Make "Default" layout really as default

### DIFF
--- a/modules/mod_menu/mod_menu.xml
+++ b/modules/mod_menu/mod_menu.xml
@@ -123,6 +123,7 @@
 					type="modulelayout"
 					label="JFIELD_ALT_LAYOUT_LABEL"
 					class="form-select"
+					default="_:default"
 					validate="moduleLayout"
 				/>
 


### PR DESCRIPTION
Use "Default" layout as default upon creating new menu module.

### Summary of Changes
Added default value to mod_menu.xml

### Testing Instructions
Go to module manager and create new module of type Menu.

### Actual result BEFORE applying this Pull Request
Module is created and in Layout field (tab Advanced) is preselected "Collapsible Default menu".

### Expected result AFTER applying this Pull Request
Module is created and in Layout field (tab Advanced) is preselected "Default".

### Documentation Changes Required
No
